### PR TITLE
modifying firebase push to set instead with uid as db key

### DIFF
--- a/assets/javascript/app.js
+++ b/assets/javascript/app.js
@@ -172,10 +172,11 @@ $(document).ready(function () {
     console.log(userid);
     database.ref('/users').once('value', function(snapshot) {
       if (!snapshot.hasChild(userid)) {
-        database.ref('/users').push({
+        database.ref('/users').set({
+          userid: {
           email: user.email,
-          uid: user.uid,
           favArray: [42],
+          }
         }) 
         console.log(database.ref('/users/' + userid));
         // query = database.ref('/users').orderByChild('uid').equalTo(firebase.auth().currentUser.uid);


### PR DESCRIPTION
using set instead of push allows us to set the uid of the user as the db key for the user object